### PR TITLE
[IMP] estate: add actions to `property` and `offer` T#69469

### DIFF
--- a/estate/models/estate_property_offer.py
+++ b/estate/models/estate_property_offer.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from odoo import api, fields, models
+from odoo import api, fields, models, _
 from dateutil.relativedelta import relativedelta
 
 
@@ -11,20 +11,20 @@ class PropertyOffer(models.Model):
     price = fields.Float(help="Price offered for the property.")
     status = fields.Selection(
         selection=[
-            ('accepted', 'Accepted'),
-            ('refused', 'Refused'),
+            ("accepted", "Accepted"),
+            ("refused", "Refused"),
         ],
         copy=False,
         help="Status of the offer for the property.",
     )
     partner_id = fields.Many2one(
-        'res.partner',
+        "res.partner",
         string="Partner",
         required=True,
         help="Partners doing an offer for the property.",
     )
     property_id = fields.Many2one(
-        'estate.property',
+        "estate.property",
         string="Property",
         required=True,
         help="Real estate properties being offered.",
@@ -53,3 +53,28 @@ class PropertyOffer(models.Model):
     def _inverse_date_deadline(self):
         for record in self:
             record.validity = (record.date_deadline - record.create_date.date()).days
+
+    def action_accept(self):
+        """ Set an offer as accepted and set the selling_price and buyer for
+        the asociated property. If the property asociated with the offer is
+        canceled or sold raises an error.
+        """
+        message = _("Property cannot accept offers.")
+        for record in self:
+            record.property_id._check_availability(message)
+            record.property_id._set_offer(record.price, record.partner_id)
+            record.status = "accepted"
+        return True
+
+    def action_refuse(self):
+        """ Set an offer as refused and unset the selling_price and buyer for
+        the asociated property in case necesary. If the property asociated with
+        the offer is canceled or sold raises an error.
+        """
+        message = _("Property cannot refuse offers.")
+        for record in self:
+            record.property_id._check_availability(message)
+            if record.status == "accepted":
+                record.property_id._set_offer(0.0, "")
+            record.status = "refused"
+        return True

--- a/estate/views/estate_property_offer_views.xml
+++ b/estate/views/estate_property_offer_views.xml
@@ -25,6 +25,8 @@
                 <field name="partner_id"/>
                 <field name="validity"/>
                 <field name="date_deadline"/>
+                <button name="action_accept" string="Accept" type="object" icon="fa-check"/>
+                <button name="action_refuse" string="Refuse" type="object" icon="fa-times"/>
                 <field name="status"/>
             </tree>
         </field>

--- a/estate/views/estate_property_views.xml
+++ b/estate/views/estate_property_views.xml
@@ -25,6 +25,10 @@
         <field name="model">estate.property</field>
         <field name="arch" type="xml">
             <form string="Property">
+                <header>
+                    <button name="action_mark_sold" type="object" string="SOLD"/>
+                    <button name="action_mark_canceled" type="object" string="CANCEL"/>
+                </header>
                 <sheet>
                     <div class="oe_title">
                         <h1>


### PR DESCRIPTION
In this PR I implement buttons with actions for `estate.property` and `estate.property.offer`. The details are included in the commit message.

This is ready for review @deivislaya

Regards!

(I'll rebase over branch 16.0 once #8 is merged.)