### PR TITLE
[FIX] estate: fix default deadline for new offer T#69469

### DIFF
--- a/estate/models/estate_property_offer.py
+++ b/estate/models/estate_property_offer.py
@@ -48,7 +48,7 @@ class PropertyOffer(models.Model):
             if record.create_date:
                 record.date_deadline = record.create_date + relativedelta(days=record.validity)
             else:
-                record.date_deadline = fields.Date.today()
+                record.date_deadline = fields.Date.today() + relativedelta(days=7)
 
     def _inverse_date_deadline(self):
         for record in self:


### PR DESCRIPTION
In this PR I fix the default `date_deadline` for `estate.property.offer`. The details are included in the commit message.

This is ready for review @deivislaya

Regards!

(I'll rebase over branch 16.0 once #9 is merged.)