### PR TITLE
[IMP] estate: add constraints to models T#69469

### DIFF
--- a/estate/models/estate_property_offer.py
+++ b/estate/models/estate_property_offer.py
@@ -7,6 +7,9 @@ from dateutil.relativedelta import relativedelta
 class PropertyOffer(models.Model):
     _name = "estate.property.offer"
     _description = "Offers for real state properties"
+    _sql_constraints = [
+        ("check_price", "CHECK(price > 0)", "The offered price must be strictly positive."),
+    ]
 
     price = fields.Float(help="Price offered for the property.")
     status = fields.Selection(

--- a/estate/models/estate_property_tag.py
+++ b/estate/models/estate_property_tag.py
@@ -6,5 +6,8 @@ from odoo import fields, models
 class PropertyTag(models.Model):
     _name = "estate.property.tag"
     _description = "Tags for real estate properties"
+    _sql_constraints = [
+        ("unique_tag", "UNIQUE(name)", "Another tag with the same name already exist."),
+    ]
 
     name = fields.Char(string="Tag", required=True, help="Tags for properties.")

--- a/estate/models/estate_property_type.py
+++ b/estate/models/estate_property_type.py
@@ -6,6 +6,9 @@ from odoo import fields, models
 class PropertyType(models.Model):
     _name = "estate.property.type"
     _description = "Real estate property type"
+    _sql_constraints = [
+        ("unique_type", "UNIQUE(name)", "Another type with the same name already exist."),
+    ]
 
     name = fields.Char(
         string="Property Type",


### PR DESCRIPTION
In this PR I added SQL constraints constrains to `estate.property`, `estate.property.tag` and `estate.property.type`. Python constrains were added to `estate.property`. The details are included in the commit message.

This is ready for review @deivislaya

Regards!

(I'll rebase over branch 16.0 once #10 is merged.)