### PR TITLE
[IMP] estate: extend models and add UI for users T#69469

### DIFF
--- a/estate/__manifest__.py
+++ b/estate/__manifest__.py
@@ -13,6 +13,7 @@
         'views/estate_property_type_views.xml',
         'views/estate_property_views.xml',
         'views/estate_menus.xml',
+        'views/res_users_views.xml',
     ],
     'application': True,
 }

--- a/estate/models/__init__.py
+++ b/estate/models/__init__.py
@@ -4,3 +4,4 @@ from . import estate_property
 from . import estate_property_type
 from . import estate_property_tag
 from . import estate_property_offer
+from . import res_users

--- a/estate/models/estate_property_offer.py
+++ b/estate/models/estate_property_offer.py
@@ -89,3 +89,16 @@ class PropertyOffer(models.Model):
                 record.property_id._set_offer(0.0, "")
             record.status = "refused"
         return True
+
+    @api.model
+    def create(self, vals):
+        """ Creating a new offer sets the asociated property in the
+        offer_received state. If the property is sold or canceled, or if the
+        price for the new offer is less than the bigger offer, raise an error.
+        """
+        property_offered = self.env["estate.property"].browse(vals["property_id"])
+        message = _("Property cannot create new offers.")
+        property_offered._check_availability(message)
+        property_offered._check_new_offer_price(vals["price"])
+        property_offered.state = "offer_received"
+        return super().create(vals)

--- a/estate/models/res_users.py
+++ b/estate/models/res_users.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+
+from odoo import fields, models
+
+
+class ResUser(models.Model):
+    _inherit = "res.users"
+
+    property_ids = fields.One2many(
+        "estate.property",
+        "salesperson_id",
+        string="Properties",
+        domain="[('state', 'in', ('new', 'offer_received'))]",
+        help="Properties managed by the salesperson."
+    )

--- a/estate/views/res_users_views.xml
+++ b/estate/views/res_users_views.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<odoo>
+    <record id="view_users_form" model="ir.ui.view">
+        <field name="name">res.users.form.inherit.estate</field>
+        <field name="model">res.users</field>
+        <field name="inherit_id" ref="base.view_users_form"/>
+        <field name="arch" type="xml">
+            <notebook position="inside">
+                <page string="Real Estate Properties">
+                    <field name="property_ids"/>
+                </page>
+            </notebook>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
In this PR I modify the CRUD methods for `estate.property`. I also extend `res.users` model and views to improve UI/UX. The details are included in the commit message.

This is ready for review @deivislaya

Regards!

(I'll rebase over branch 16.0 once #12 is merged.)