### PR TITLE
[IMP] estate: add invoicing to `estate.property` T#69469

### DIFF
--- a/estate_account/README.rst
+++ b/estate_account/README.rst
@@ -1,0 +1,9 @@
+Real Estate module for accounting (`estate_account`)
+====================================================
+
+authors: Vauxoo
+---------------
+
+license: OPL-1
+
+Real Estate Accounting module for technical training Odoo.

--- a/estate_account/__init__.py
+++ b/estate_account/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+
+from . import models

--- a/estate_account/__manifest__.py
+++ b/estate_account/__manifest__.py
@@ -1,0 +1,12 @@
+# -*- coding: utf-8 -*-
+
+{
+    'name': 'Real Estate Accounting',
+    'author': 'Vauxoo',
+    'version': '16.0.1.0.0',
+    'license': 'OPL-1',
+    'depends': ['base', 'estate', 'account'],
+    'auto_install': True,
+    'application': True,
+    'installable': True,
+}

--- a/estate_account/models/__init__.py
+++ b/estate_account/models/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+
+from . import estate_property

--- a/estate_account/models/estate_property.py
+++ b/estate_account/models/estate_property.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+
+from odoo import models, Command
+
+
+class Property(models.Model):
+    _inherit = "estate.property"
+
+    def action_mark_sold(self):
+        res = super().action_mark_sold()
+        journal = self.env["account.journal"].search([("type", "=", "sale")], limit=1)
+        for record in self:
+            values = self._prepare_account_move_values(journal, record)
+            self.env["account.move"].create(values)
+        return res
+
+    def _prepare_account_move_values(self, journal, record):
+        record.ensure_one()
+        values = {
+            "partner_id": record.buyer_id.id,
+            "move_type": "out_invoice",
+            "journal_id": journal.id,
+            "invoice_line_ids": [
+                Command.create({
+                    "name": record.name,
+                    "quantity": 1.0,
+                    "price_unit": record.selling_price * 6.0 / 100.0,
+                }),
+                Command.create({
+                    "name": "Administrative fees",
+                    "quantity": 1.0,
+                    "price_unit": 100.0,
+                }),
+            ],
+        }
+        return values


### PR DESCRIPTION
In this PR, I add the `estate_account` module (which depends on `account`) to be able to do invoicing for properties sold. For this, I extend the model `estate.property`. The details are included in the commit message.

This is ready for review @deivislaya

Regards!

(I'll rebase over branch 16.0 once #13 is merged.)