### PR TITLE
[IMP] estate: add demo and functional data T#69469

### DIFF
--- a/estate/__manifest__.py
+++ b/estate/__manifest__.py
@@ -14,6 +14,9 @@
         'views/estate_property_views.xml',
         'views/estate_menus.xml',
         'views/res_users_views.xml',
+        'data/estate.property.type.csv',
+        'demo/estate_property.xml',
+        'demo/estate_property_offer.xml',
     ],
     'application': True,
 }

--- a/estate/data/estate.property.type.csv
+++ b/estate/data/estate.property.type.csv
@@ -1,0 +1,5 @@
+"id","name","sequence"
+"estate.property_type_res","Residential",0
+"estate.property_type_com","Commercial",1
+"estate.property_type_ind","Industrial",2
+"estate.property_type_lan","Land",3

--- a/estate/demo/estate_property.xml
+++ b/estate/demo/estate_property.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0"?>
+<odoo noupdate="1">
+    <record id="property_1" model="estate.property">
+        <field name="name">Big Villa</field>
+        <field name="state">new</field>
+        <field name="description">A nice and big villa</field>
+        <field name="postcode">12345</field>
+        <field name="date_availability">2020-02-02</field>
+        <field name="expected_price">1600000</field>
+        <field name="bedrooms">6</field>
+        <field name="living_area">100</field>
+        <field name="facades">4</field>
+        <field name="garage">True</field>
+        <field name="garden">True</field>
+        <field name="garden_area">100000</field>
+        <field name="garden_orientation">south</field>
+        <field name="property_type_id" ref="estate.property_type_res"/>
+    </record>
+
+    <record id="property_2" model="estate.property">
+        <field name="name">Trailer home</field>
+        <field name="state">canceled</field>
+        <field name="description">Home in a trailer park</field>
+        <field name="postcode">54321</field>
+        <field name="date_availability">1970-01-01</field>
+        <field name="expected_price">100000</field>
+        <field name="selling_price">120000</field>
+        <field name="bedrooms">1</field>
+        <field name="living_area">10</field>
+        <field name="facades">4</field>
+        <field name="garage">False</field>
+        <field name="property_type_id" ref="estate.property_type_res"/>
+    </record>
+
+    <record id="property_3" model="estate.property">
+        <field name="name">Hotel in Las Vegas</field>
+        <field name="state">offer_received</field>
+        <field name="description">Hotel in the center of Las Vegas</field>
+        <field name="postcode">54321</field>
+        <field name="date_availability">1970-01-01</field>
+        <field name="expected_price">10000000</field>
+        <field name="bedrooms">500</field>
+        <field name="living_area">10000</field>
+        <field name="facades">4</field>
+        <field name="garage">True</field>
+        <field name="garden">True</field>
+        <field name="garden_area">100000</field>
+        <field name="garden_orientation">south</field>
+        <field name="property_type_id" ref="estate.property_type_com"/>
+        <field name="offer_ids" eval="[
+            Command.create({
+                'partner_id': ref('base.res_partner_1'),
+                'price': 9.5e5,
+                'validity': 120,
+            }),
+            Command.create({
+                'partner_id': ref('base.res_partner_2'),
+                'price': 9.75e5,
+                'validity': 120,
+            }),
+            Command.create({
+                'partner_id': ref('base.res_partner_1'),
+                'price': 1.2e6,
+                'validity': 120,
+            }),
+        ]"/>
+    </record>
+</odoo>

--- a/estate/demo/estate_property_offer.xml
+++ b/estate/demo/estate_property_offer.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0"?>
+<odoo>
+    <record id="property_offer_1" model="estate.property.offer">
+        <field name="partner_id" ref="base.res_partner_12"/>
+        <field name="property_id" ref="estate.property_1"/>
+        <field name="price">10000</field>
+        <field name="status">refused</field>
+        <field name="validity">14</field>
+        <field name="date_deadline" eval="datetime.now().date() + relativedelta(days=14)"/>
+    </record>
+
+    <record id="property_offer_2" model="estate.property.offer">
+        <field name="partner_id" ref="base.res_partner_12"/>
+        <field name="property_id" ref="estate.property_1"/>
+        <field name="price">1500000</field>
+        <field name="status">refused</field>
+        <field name="validity">14</field>
+        <field name="date_deadline" eval="datetime.now().date() + relativedelta(days=14)"/>
+    </record>
+
+    <record id="property_offer_3" model="estate.property.offer">
+        <field name="partner_id" ref="base.res_partner_2"/>
+        <field name="property_id" ref="estate.property_1"/>
+        <field name="price">1500001</field>
+        <field name="validity">14</field>
+        <field name="date_deadline" eval="datetime.now().date() + relativedelta(days=14)"/>
+    </record>
+</odoo>


### PR DESCRIPTION
In this commit, I add functional data for `estate.property.type`, and demo data for `estate.property`. `estate.property.type` is added to the module, as to provide minimal functionality for the former and examples for the later two.

Everything is implemented as specified in the "Define module data" section in the technical training.

It was checked that the state of the instances of `estate.property` in the demo data was consistent, and that the order of loading of demo data was consistent with the constraints on the data.

This PR is ready for review @deivislaya.